### PR TITLE
Minor changes to project urls

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -8,7 +8,7 @@ projects1:
     title: "muscle-BIDS"
     image:  mskbids.jpg
     description: n/a
-    url: https://www.github.com/imr-framework/virtual-scanner
+    url: https://muscle-bids.github.io
   - id: "p-3"
     title: "Pulseq"
     image:  pulseq.png
@@ -30,7 +30,7 @@ projects2:
     title: "NeuroLibre"
     image:  nl.png
     description: n/a
-    url: https://muscle-bids.github.io
+    url: https://neurolibre.org/
   - id: "p-6"
     title: "VENUS"
     image:  venus_logo.png

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -3,12 +3,12 @@ projects1:
     title: "Virtual Scanner"
     image:  vscan.jpg
     description: n/a
-    url: www.github.com/imr-framework/virtual-scanner
+    url: https://www.github.com/imr-framework/virtual-scanner
   - id: "p-2"
     title: "muscle-BIDS"
     image:  mskbids.jpg
     description: n/a
-    url: www.github.com/imr-framework/virtual-scanner
+    url: https://www.github.com/imr-framework/virtual-scanner
   - id: "p-3"
     title: "Pulseq"
     image:  pulseq.png


### PR DESCRIPTION
Changes:

- URLs for `Virtual Scanner` and `muscle-BIDS` were broken
  + looks like they were resolved as relative urls because the `https://` part was missing, so that was added
- URLs for `muscle-BIDS` and `neurolibre` didn't look right, so they were updated
  + not sure what the appropriate url for `neurolibre` is, so feel free to update it
  + also not sure if `muscle-BIDS` should point to the project website, or to the github issues in the idea-pitches repository, but using the project website for now because that's how it was initially